### PR TITLE
P2: bench harness + contract tests + mixed full tamper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,12 @@ tools/top_pipelines.json
 
 # local test corpora (not tracked)
 tests/data/
-
 /tests/data/
+
+# Bench / torture outputs (P2)
+bench_out/
+tools/p2/out/
+**/*.metrics
+**/*.log
+**/*.md
+**/*.csv

--- a/tests/test_p2_bench_smoke.py
+++ b/tests/test_p2_bench_smoke.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.p2, pytest.mark.bench]
+
+
+if os.environ.get("RUN_P2_SMOKE") != "1":
+    pytest.skip("set RUN_P2_SMOKE=1 to enable P2 bench smoke test", allow_module_level=True)
+
+
+def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), text=True, capture_output=True)
+
+
+def test_p2_run_bench_smoke(tmp_path: Path) -> None:
+    out_root = tmp_path / "p2_data"
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    gen = _run(
+        ["python3", "tools/p2/bench_dataset_gen.py", "--out", str(out_root), "--preset", "tiny_smoke"],
+        cwd=Path.cwd(),
+    )
+    assert gen.returncode == 0, f"dataset_gen failed\nstdout:\n{gen.stdout}\nstderr:\n{gen.stderr}"
+
+    ds = out_root / "tiny_smoke"
+    assert (ds / "in").is_dir()
+
+    bench = _run(["bash", "tools/p2/run_bench.sh", str(ds), "--buckets", "4"], cwd=Path.cwd())
+    assert bench.returncode == 0, f"run_bench failed\nstdout:\n{bench.stdout}\nstderr:\n{bench.stderr}"

--- a/tests/test_p2_runner_contract.py
+++ b/tests/test_p2_runner_contract.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.p2
+
+
+def _read_csv_rows(csv_path: Path) -> list[dict[str, str]]:
+    lines = csv_path.read_text(encoding="utf-8").splitlines()
+    assert lines, f"CSV vuoto: {csv_path}"
+    header = lines[0].split(",")
+    rows: list[dict[str, str]] = []
+    for ln in lines[1:]:
+        if not ln.strip():
+            continue
+        parts = ln.split(",")
+        # note può contenere virgole? nel nostro runner no: lo teniamo semplice
+        if len(parts) != len(header):
+            raise AssertionError(f"CSV malformato: {csv_path}\nLINE: {ln}")
+        rows.append(dict(zip(header, parts, strict=True)))
+    return rows
+
+
+@pytest.mark.skipif(os.environ.get("RUN_P2_SMOKE") != "1", reason="set RUN_P2_SMOKE=1 to enable")
+def test_p2_runner_marks_single_as_na_on_mixed_input(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    runner = repo_root / "tools" / "p2" / "run_bench.sh"
+    assert runner.is_file(), f"manca runner: {runner}"
+
+    in_dir = tmp_path / "in_mixed"
+    in_dir.mkdir(parents=True)
+
+    (in_dir / "hello.txt").write_text("ciao\n", encoding="utf-8")
+    # BIN: include NUL -> non text-only
+    (in_dir / "bin.dat").write_bytes(b"\x00\x01\x02\x03\xff")
+
+    out_root = tmp_path / "bench_out"
+    out_root.mkdir(parents=True)
+
+    env = os.environ.copy()
+    env["OCF_P2_OUT"] = str(out_root)
+
+    cmd = [
+        "bash",
+        str(runner),
+        str(in_dir),
+        "--buckets",
+        "2",
+        "--modes",
+        "classic,single,mixed",
+        "--skip-verify",
+        "--skip-unpack",
+        "--timeout",
+        "60",
+    ]
+    cp = subprocess.run(cmd, text=True, capture_output=True, env=env)
+    assert cp.returncode == 0, f"runner fallito\nstdout:\n{cp.stdout}\nstderr:\n{cp.stderr}"
+
+    # Prendi la directory run più recente
+    runs = sorted([p for p in out_root.iterdir() if p.is_dir()], key=lambda p: p.name)
+    assert runs, f"nessun run creato in {out_root}\nstdout:\n{cp.stdout}\nstderr:\n{cp.stderr}"
+    run_dir = runs[-1]
+    csv_path = run_dir / "bench.csv"
+    assert csv_path.is_file(), f"manca bench.csv in {run_dir}"
+
+    rows = _read_csv_rows(csv_path)
+
+    def pick(mode: str, step: str) -> dict[str, str]:
+        for r in rows:
+            if r["mode"] == mode and r["step"] == step:
+                return r
+        raise AssertionError(f"manca riga mode={mode} step={step} in {csv_path}")
+
+    r_classic = pick("classic", "pack")
+    r_mixed = pick("mixed", "pack")
+    r_single = pick("single", "pack")
+
+    assert r_classic["rc"] == "0", f"classic pack deve riuscire: {r_classic}"
+    assert r_mixed["rc"] == "0", f"mixed pack deve riuscire: {r_mixed}"
+
+    assert r_single["rc"] == "NA", f"single su input mixed deve essere NA (non FAIL): {r_single}"
+    assert r_single["note"].startswith("NA:"), f"nota single deve iniziare con NA:: {r_single}"

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+# tools package (utility scripts)

--- a/tools/p2/__init__.py
+++ b/tools/p2/__init__.py
@@ -1,0 +1,1 @@
+# P2 tooling package (bench/torture helpers)

--- a/tools/p2/bench_dataset_gen.py
+++ b/tools/p2/bench_dataset_gen.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import string
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Final
+
+PRESETS: Final[set[str]] = {
+    "tiny_smoke",
+    "text_corpus_small",
+    "mixed_corpus_small",
+    "bigfile_single",
+}
+
+
+@dataclass(frozen=True)
+class DatasetMeta:
+    preset: str
+    seed: int
+    root: str
+    note: str
+    files_written: int
+    bytes_written: int
+
+
+def _write_bytes(path: Path, data: bytes) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return len(data)
+
+
+def _write_text(path: Path, text: str) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    b = text.encode("utf-8")
+    path.write_bytes(b)
+    return len(b)
+
+
+def _rand_word(rng: random.Random, min_len: int = 3, max_len: int = 12) -> str:
+    n = rng.randint(min_len, max_len)
+    alphabet = string.ascii_lowercase
+    return "".join(rng.choice(alphabet) for _ in range(n))
+
+
+def _rand_line(rng: random.Random) -> str:
+    # un po' di unicode, numeri, e roba "fattura-like"
+    parts = []
+    parts.append(_rand_word(rng).capitalize())
+    parts.append(_rand_word(rng))
+    parts.append(str(rng.randint(0, 10_000_000)))
+    parts.append(rng.choice(["€", "Ω", "✓", "Δ", "π", "—", "…", "漢字", "è", "à", "ù"]))
+    parts.append(rng.choice(["IVA", "Totale", "Riga", "Codice", "Cliente", "Note"]))
+    return " ".join(parts)
+
+
+def _make_text_file(rng: random.Random, *, lines: int, long_line: bool = False) -> str:
+    out = []
+    for _ in range(lines):
+        out.append(_rand_line(rng))
+    if long_line:
+        # una riga esagerata
+        tail = " | ".join(_rand_line(rng) for _ in range(200))
+        out.append(tail)
+    return "\n".join(out) + "\n"
+
+
+def _make_jsonl(rng: random.Random, *, rows: int) -> str:
+    out = []
+    for i in range(rows):
+        obj = {
+            "id": i,
+            "name": _rand_word(rng),
+            "amount": rng.randint(0, 1_000_000),
+            "flag": rng.choice([True, False]),
+            "note": _rand_line(rng),
+        }
+        out.append(json.dumps(obj, ensure_ascii=False))
+    return "\n".join(out) + "\n"
+
+
+def _write_random_bin(rng: random.Random, path: Path, size: int) -> int:
+    # randbytes è veloce e deterministic
+    remaining = size
+    chunk = 1 << 16
+    written = 0
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as f:
+        while remaining > 0:
+            n = min(chunk, remaining)
+            f.write(rng.randbytes(n))
+            written += n
+            remaining -= n
+    return written
+
+
+def _generate_tiny_smoke(root: Path, rng: random.Random) -> tuple[int, int, str]:
+    files = 0
+    bytes_ = 0
+    note = "Tiny dataset per smoke benchmark (veloce)."
+
+    bytes_ += _write_text(root / "hello.txt", "Ciao\n")
+    files += 1
+
+    bytes_ += _write_text(root / "nested" / "deep" / "unicode.txt", "Ωmega ✓\n")
+    files += 1
+
+    bytes_ += _write_bytes(root / "nested" / "deep" / "empty.txt", b"")
+    files += 1
+
+    bytes_ += _write_bytes(root / "bin" / "tiny.bin", b"\x00\x01\x02\x03")
+    files += 1
+
+    return files, bytes_, note
+
+
+def _generate_text_corpus_small(root: Path, rng: random.Random) -> tuple[int, int, str]:
+    files = 0
+    bytes_ = 0
+    note = "Corpus text small: unicode, linee lunghe, jsonl, e file vuoti."
+
+    # 20 vuoti
+    for i in range(20):
+        bytes_ += _write_bytes(root / "empty" / f"e_{i:03d}.txt", b"")
+        files += 1
+
+    # 80 txt normali
+    for i in range(80):
+        txt = _make_text_file(rng, lines=rng.randint(10, 60))
+        bytes_ += _write_text(root / "docs" / f"doc_{i:03d}.txt", txt)
+        files += 1
+
+    # 40 txt con linee lunghe
+    for i in range(40):
+        txt = _make_text_file(rng, lines=rng.randint(5, 20), long_line=True)
+        bytes_ += _write_text(root / "long" / f"long_{i:03d}.md", txt)
+        files += 1
+
+    # 60 jsonl
+    for i in range(60):
+        txt = _make_jsonl(rng, rows=rng.randint(50, 200))
+        bytes_ += _write_text(root / "jsonl" / f"data_{i:03d}.jsonl", txt)
+        files += 1
+
+    return files, bytes_, note
+
+
+def _generate_mixed_corpus_small(root: Path, rng: random.Random) -> tuple[int, int, str]:
+    files = 0
+    bytes_ = 0
+    note = "Corpus mixed small: testo+bin, include binari minuscoli e file vuoti."
+
+    # parte testo (120)
+    for i in range(120):
+        txt = _make_text_file(rng, lines=rng.randint(5, 40), long_line=(i % 17 == 0))
+        bytes_ += _write_text(root / "text" / f"t_{i:03d}.txt", txt)
+        files += 1
+
+    # vuoti (20)
+    for i in range(20):
+        bytes_ += _write_bytes(root / "text" / "empty" / f"e_{i:03d}.txt", b"")
+        files += 1
+
+    # binari random (50) 1..64KB
+    for i in range(50):
+        sz = rng.randint(1024, 64 * 1024)
+        bytes_ += _write_random_bin(rng, root / "bin" / f"r_{i:03d}.bin", sz)
+        files += 1
+
+    # binari minuscoli (10) 0..32 bytes
+    for i in range(10):
+        sz = rng.randint(0, 32)
+        bytes_ += _write_random_bin(rng, root / "bin" / "tiny" / f"tiny_{i:03d}.bin", sz)
+        files += 1
+
+    return files, bytes_, note
+
+
+def _generate_bigfile_single(root: Path, rng: random.Random, big_mb: int) -> tuple[int, int, str]:
+    files = 0
+    bytes_ = 0
+    note = f"Bigfile torture: ~{big_mb}MB random.bin + ~{big_mb}MB pseudo_text.txt (+ empty)."
+
+    bytes_ += _write_bytes(root / "nested" / "deep" / "empty.txt", b"")
+    files += 1
+
+    # random.bin
+    target = big_mb * 1024 * 1024
+    bytes_ += _write_random_bin(rng, root / "big" / "random.bin", target)
+    files += 1
+
+    # pseudo_text.txt (molto comprimibile)
+    path = root / "big" / "pseudo_text.txt"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with path.open("wb") as f:
+        while written < target:
+            line = _make_text_file(rng, lines=50, long_line=True)
+            b = line.encode("utf-8")
+            take = min(len(b), target - written)
+            f.write(b[:take])
+            written += take
+    bytes_ += written
+    files += 1
+
+    return files, bytes_, note
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Generate deterministic datasets for P2 bench/torture.")
+    ap.add_argument("--out", required=True, help="Output root directory (datasets will be created under it).")
+    ap.add_argument("--preset", required=True, choices=sorted(PRESETS))
+    ap.add_argument("--seed", type=int, default=1337, help="Deterministic seed.")
+    ap.add_argument("--big-mb", type=int, default=250, help="For bigfile_single: size per big file in MB.")
+    args = ap.parse_args()
+
+    out_root = Path(args.out).expanduser().resolve()
+    ds_dir = out_root / args.preset / "in"
+    ds_dir.mkdir(parents=True, exist_ok=True)
+
+    rng = random.Random(args.seed)
+
+    files = 0
+    bytes_ = 0
+    note = ""
+
+    if args.preset == "tiny_smoke":
+        files, bytes_, note = _generate_tiny_smoke(ds_dir, rng)
+    elif args.preset == "text_corpus_small":
+        files, bytes_, note = _generate_text_corpus_small(ds_dir, rng)
+    elif args.preset == "mixed_corpus_small":
+        files, bytes_, note = _generate_mixed_corpus_small(ds_dir, rng)
+    elif args.preset == "bigfile_single":
+        files, bytes_, note = _generate_bigfile_single(ds_dir, rng, args.big_mb)
+    else:
+        raise AssertionError("preset non gestito")
+
+    meta = DatasetMeta(
+        preset=args.preset,
+        seed=args.seed,
+        root=str(ds_dir),
+        note=note,
+        files_written=files,
+        bytes_written=bytes_,
+    )
+    meta_path = out_root / args.preset / "dataset.json"
+    meta_path.write_text(json.dumps(asdict(meta), ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print(f"OK: generated preset={args.preset} root={ds_dir}")
+    print(f"OK: files={files} bytes={bytes_}")
+    print(f"OK: meta -> {meta_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/p2/run_bench.sh
+++ b/tools/p2/run_bench.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TIME_BIN="/usr/bin/time"
+if [[ ! -x "$TIME_BIN" ]]; then
+  echo "ERROR: missing $TIME_BIN (install package 'time')" >&2
+  exit 2
+fi
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: manca '$1' nel PATH" >&2; exit 2; }; }
+need du
+need awk
+need date
+
+HAS_RG=0
+if command -v rg >/dev/null 2>&1; then
+  HAS_RG=1
+fi
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <dataset_dir_or_input_dir> [--buckets N] [--modes classic,single,mixed] [--skip-verify] [--skip-unpack] [--timeout SEC]" >&2
+  exit 2
+fi
+
+DATASET="$1"
+shift || true
+
+BUCKETS="8"
+MODES="classic,single,mixed"
+SKIP_VERIFY=0
+SKIP_UNPACK=0
+TIMEOUT_SEC=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --buckets) BUCKETS="$2"; shift 2;;
+    --modes) MODES="$2"; shift 2;;
+    --skip-verify) SKIP_VERIFY=1; shift 1;;
+    --skip-unpack) SKIP_UNPACK=1; shift 1;;
+    --timeout) TIMEOUT_SEC="$2"; shift 2;;
+    *) echo "ERROR: arg sconosciuto: $1" >&2; exit 2;;
+  esac
+done
+
+if [[ -d "$DATASET/in" ]]; then
+  IN_DIR="$(cd "$DATASET/in" && pwd)"
+  DS_NAME="$(basename "$(cd "$DATASET" && pwd)")"
+else
+  IN_DIR="$(cd "$DATASET" && pwd)"
+  DS_NAME="$(basename "$IN_DIR")"
+fi
+
+OUT_ROOT="${OCF_P2_OUT:-bench_out/ocf_p2}"
+mkdir -p "$OUT_ROOT"
+
+TS="$(date +%Y%m%d-%H%M%S)"
+RUN_DIR="$OUT_ROOT/${TS}_${DS_NAME}"
+LOG_DIR="$RUN_DIR/logs"
+mkdir -p "$LOG_DIR"
+
+CSV="$RUN_DIR/bench.csv"
+MD="$RUN_DIR/bench.md"
+
+echo "dataset,mode,step,rc,elapsed_sec,max_rss_kb,in_bytes,out_bytes,ratio,note" > "$CSV"
+
+in_bytes="$(du -sb "$IN_DIR" | awk '{print $1}')"
+
+parse_metric() {
+  local key="$1"
+  local file="$2"
+  if [[ ! -f "$file" ]]; then
+    echo "NA"
+    return
+  fi
+  if [[ "$HAS_RG" == "1" ]]; then
+    rg -N "^${key}=" "$file" | head -n 1 | cut -d= -f2 || echo "NA"
+    return
+  fi
+  awk -F= -v k="$key" '$1==k {print $2; exit}' "$file" 2>/dev/null || echo "NA"
+}
+
+run_timed() {
+  local mode="$1"; shift
+  local step="$1"; shift
+  local log="$LOG_DIR/${mode}_${step}.log"
+  local met="$LOG_DIR/${mode}_${step}.metrics"
+
+  local -a cmd=( "$@" )
+
+  if [[ -n "$TIMEOUT_SEC" ]]; then
+    if command -v timeout >/dev/null 2>&1; then
+      cmd=( timeout "$TIMEOUT_SEC" "${cmd[@]}" )
+    else
+      echo "WARN: --timeout richiesto ma 'timeout' non presente; ignoro." >&2
+    fi
+  fi
+
+  set +e
+  "$TIME_BIN" -f "ELAPSED_SEC=%e\nMAX_RSS_KB=%M" -o "$met" "${cmd[@]}" >"$log" 2>&1
+  local rc="$?"
+  set -e
+
+  local elapsed rss
+  elapsed="$(parse_metric "ELAPSED_SEC" "$met")"
+  rss="$(parse_metric "MAX_RSS_KB" "$met")"
+
+  echo "$rc|$elapsed|$rss|$log"
+}
+
+ratio_of() {
+  local out_b="$1"
+  python3 - <<PY
+in_b = int("$in_bytes")
+out_b = int("$out_b")
+print("NA" if in_b <= 0 else f"{out_b / in_b:.4f}")
+PY
+}
+
+is_single_not_applicable() {
+  local log="$1"
+  if [[ ! -f "$log" ]]; then
+    return 1
+  fi
+  if rg -N -i "text-only|non.?utf|utf-8|nul|binary|non.*testo|not.*text" "$log" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+bench_mode() {
+  local mode="$1"
+  local out_dir="$RUN_DIR/out_${mode}"
+  local restored="$RUN_DIR/restored_${mode}"
+  rm -rf "$out_dir" "$restored"
+  mkdir -p "$out_dir" "$restored"
+
+  local out_bytes="NA"
+  local ratio="NA"
+  local rc elapsed rss log note
+
+  if [[ "$mode" == "classic" ]]; then
+    IFS='|' read -r rc elapsed rss log < <(run_timed "$mode" "pack" gcc-ocf dir pack "$IN_DIR" "$out_dir" --buckets "$BUCKETS")
+  elif [[ "$mode" == "single" ]]; then
+    IFS='|' read -r rc elapsed rss log < <(run_timed "$mode" "pack" gcc-ocf dir pack "$IN_DIR" "$out_dir" --single-container)
+  elif [[ "$mode" == "mixed" ]]; then
+    IFS='|' read -r rc elapsed rss log < <(run_timed "$mode" "pack" gcc-ocf dir pack "$IN_DIR" "$out_dir" --single-container-mixed)
+  else
+    echo "ERROR: unknown mode: $mode" >&2
+    exit 3
+  fi
+
+  note=""
+  if [[ "$rc" == "0" ]]; then
+    out_bytes="$(du -sb "$out_dir" | awk '{print $1}')"
+    ratio="$(ratio_of "$out_bytes")"
+  else
+    if [[ "$mode" == "single" ]] && is_single_not_applicable "$log"; then
+      note="NA: single-container is text-only (dataset contains non-text)"
+      rc="NA"
+      elapsed="NA"
+      rss="NA"
+    else
+      note="FAIL: pack"
+    fi
+    out_bytes="NA"
+    ratio="NA"
+  fi
+
+  echo "$DS_NAME,$mode,pack,$rc,$elapsed,$rss,$in_bytes,$out_bytes,$ratio,$note" >> "$CSV"
+
+  if [[ "$rc" != "0" ]]; then
+    echo "$DS_NAME,$mode,verify_full,SKIP,NA,NA,$in_bytes,$out_bytes,$ratio,SKIP: pack not ok" >> "$CSV"
+    echo "$DS_NAME,$mode,unpack,SKIP,NA,NA,$in_bytes,$out_bytes,$ratio,SKIP: pack not ok" >> "$CSV"
+    return
+  fi
+
+  if [[ "$SKIP_VERIFY" == "0" ]]; then
+    IFS='|' read -r rc elapsed rss log < <(run_timed "$mode" "verify_full" gcc-ocf dir verify "$out_dir" --full)
+    note=""
+    if [[ "$rc" != "0" ]]; then note="FAIL: verify_full"; fi
+    echo "$DS_NAME,$mode,verify_full,$rc,$elapsed,$rss,$in_bytes,$out_bytes,$ratio,$note" >> "$CSV"
+  else
+    echo "$DS_NAME,$mode,verify_full,SKIP,NA,NA,$in_bytes,$out_bytes,$ratio,SKIP: requested" >> "$CSV"
+  fi
+
+  if [[ "$SKIP_UNPACK" == "0" ]]; then
+    IFS='|' read -r rc elapsed rss log < <(run_timed "$mode" "unpack" gcc-ocf dir unpack "$out_dir" "$restored")
+    note=""
+    if [[ "$rc" != "0" ]]; then note="FAIL: unpack"; fi
+    echo "$DS_NAME,$mode,unpack,$rc,$elapsed,$rss,$in_bytes,$out_bytes,$ratio,$note" >> "$CSV"
+  else
+    echo "$DS_NAME,$mode,unpack,SKIP,NA,NA,$in_bytes,$out_bytes,$ratio,SKIP: requested" >> "$CSV"
+  fi
+}
+
+echo "INFO: dataset=$DS_NAME input=$IN_DIR"
+echo "INFO: run_dir=$RUN_DIR"
+echo "INFO: buckets=$BUCKETS"
+echo "INFO: modes=$MODES"
+echo "INFO: skip_verify=$SKIP_VERIFY skip_unpack=$SKIP_UNPACK timeout=${TIMEOUT_SEC:-none}"
+
+IFS=',' read -r -a mode_list <<< "$MODES"
+for m in "${mode_list[@]}"; do
+  bench_mode "$m"
+done
+
+{
+  echo "# OCF P2 Bench"
+  echo
+  echo "- dataset: \`$DS_NAME\`"
+  echo "- input: \`$IN_DIR\`"
+  echo "- run: \`$RUN_DIR\`"
+  echo "- modes: \`$MODES\`"
+  echo "- buckets: \`$BUCKETS\`"
+  echo "- skip_verify: \`$SKIP_VERIFY\`"
+  echo "- skip_unpack: \`$SKIP_UNPACK\`"
+  echo "- timeout: \`${TIMEOUT_SEC:-none}\`"
+  echo
+  echo "## Results (CSV)"
+  echo
+  echo "\`\`\`"
+  if command -v column >/dev/null 2>&1; then
+    column -t -s, "$CSV"
+  else
+    cat "$CSV"
+  fi
+  echo "\`\`\`"
+} > "$MD"
+
+echo "OK: CSV -> $CSV"
+echo "OK: MD  -> $MD"
+echo "OK: logs -> $LOG_DIR"

--- a/tools/p2/run_bigfiles.sh
+++ b/tools/p2/run_bigfiles.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bigfiles torture runner (pragmatic defaults).
+#
+# Usage:
+#   bash tools/p2/run_bigfiles.sh /tmp/ocf_p2_data
+#     [--big-mb 64]
+#     [--buckets 8]
+#     [--modes classic,single,mixed | mixed]
+#     [--regen]
+#     [--skip-verify]
+#     [--skip-unpack]
+#     [--timeout SEC]
+#
+# Default: big-mb=64, modes=mixed, skip-unpack=1, timeout=600
+#
+# Output dir is controlled by:
+#   OCF_P2_OUT (default: bench_out/ocf_p2) used by run_bench.sh
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <out_root> [--big-mb N] [--buckets N] [--modes ...] [--regen] [--skip-verify] [--skip-unpack] [--timeout SEC]" >&2
+  exit 2
+fi
+
+OUT_ROOT="$1"
+shift || true
+
+BIG_MB="64"
+BUCKETS="8"
+MODES="mixed"
+REGEN=0
+SKIP_VERIFY=0
+SKIP_UNPACK=1
+TIMEOUT_SEC="600"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --big-mb) BIG_MB="$2"; shift 2;;
+    --buckets) BUCKETS="$2"; shift 2;;
+    --modes) MODES="$2"; shift 2;;
+    --mode) MODES="$2"; shift 2;; # alias
+    --regen) REGEN=1; shift 1;;
+    --skip-verify) SKIP_VERIFY=1; shift 1;;
+    --skip-unpack) SKIP_UNPACK=1; shift 1;;
+    --timeout) TIMEOUT_SEC="$2"; shift 2;;
+    *) echo "ERROR: arg sconosciuto: $1" >&2; exit 2;;
+  esac
+done
+
+DS_DIR="$OUT_ROOT/bigfile_single"
+META="$DS_DIR/dataset.json"
+
+if [[ "$REGEN" == "1" || ! -f "$META" ]]; then
+  python3 tools/p2/bench_dataset_gen.py --out "$OUT_ROOT" --preset bigfile_single --big-mb "$BIG_MB"
+else
+  echo "INFO: reuse dataset (exists): $DS_DIR"
+fi
+
+# Forward to run_bench.sh (which handles OCF_P2_OUT)
+args=( "$DS_DIR" --buckets "$BUCKETS" --modes "$MODES" --timeout "$TIMEOUT_SEC" )
+if [[ "$SKIP_VERIFY" == "1" ]]; then args+=( --skip-verify ); fi
+if [[ "$SKIP_UNPACK" == "1" ]]; then args+=( --skip-unpack ); fi
+
+bash tools/p2/run_bench.sh "${args[@]}"


### PR DESCRIPTION
Closes #4

## Cosa include
- P2 bench harness: dataset gen + runner + bigfiles
- Runner: single su input mixed => NA (non FAIL)
- Mixed verify full: concat mismatch trattato come tamper (exit 13)
- Output bench fuori repo: bench_out/ (gitignored)

## Risultati (bigfile_single)
- 64MB (run 20260118-181548): pack 267.30s, max_rss 2811828 KB, ratio 0.7910; verify_full 51.25s, max_rss 2325052 KB
- 128MB (run 20260118-184823): pack 134.07s, max_rss 1326320 KB, ratio 0.7802; verify_full 27.36s, max_rss 1375960 KB

## Note
- CPU ~99%, major faults 0 (time -v)
